### PR TITLE
bugfix/accurics_remediation_5797821757984984 - Auto Generated Pull Request From Accurics

### DIFF
--- a/terraform/aws/modules/storage/main.tf
+++ b/terraform/aws/modules/storage/main.tf
@@ -61,6 +61,7 @@ resource "aws_db_instance" "km_db" {
   tags = merge(var.default_tags, {
     Name = "km_db_${var.environment}"
   })
+  backup_retention_period = 30
 }
 
 resource "aws_ssm_parameter" "km_ssm_db_host" {


### PR DESCRIPTION
Automated backups can be enabled using AWS Console or AWS CLI.
 In AWS Console - 
 1. Sign in to the AWS Console and go to the Amazon RDS console.
 2. Select Databases, and then choose the DB instance that you want to modify in the navigation pane.
 3. Select Modify.
 4. For Backup retention period, select the recommended 30 days value.
 5. Select Continue.
 6. Select Apply immediately.
 7. On the confirmation page, select Modify DB instance to save your changes and enable automated backups.
 Using AWS CLI - 
 Use the command : 'modify-db-instance' with the following parameters: 
   a.--db-instance-identifier 
   b. --backup-retention-period 
   c. --apply-immediately 
This will enable automated backups for AWS RDS instances.